### PR TITLE
fix unhandled exception in the init loop in case of network error

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -31,7 +31,7 @@ function api.configure(token, debug)
     api.token = assert(token, 'Please specify your bot API token you received from @BotFather!')
     repeat
         api.info = api.get_me()
-    until api.info.result
+    until api.info and api.info.result
     api.info = api.info.result
     api.info.name = api.info.first_name
     return api


### PR DESCRIPTION
If network is not available, `api.get_me()` will return false instead of object, which will create unhandled exception trying to access boolean as a table. This simple fix ensures we have 'non-false' property before moving further.