### PR TITLE
chore: fix rockspec source URLs for v3.1 release

### DIFF
--- a/telegram-bot-lua-3.0-0.rockspec
+++ b/telegram-bot-lua-3.0-0.rockspec
@@ -1,9 +1,8 @@
 package = "telegram-bot-lua"
 version = "3.0-0"
 source = {
-    url = "git://github.com/wrxck/telegram-bot-lua.git",
-    dir = "telegram-bot-lua",
-    tag = "v3.0"
+    url = "https://github.com/wrxck/telegram-bot-lua/archive/refs/tags/v3.0.tar.gz",
+    dir = "telegram-bot-lua-3.0"
 }
 description = {
     summary = "A feature-filled Telegram bot API library",

--- a/telegram-bot-lua-3.1-0.rockspec
+++ b/telegram-bot-lua-3.1-0.rockspec
@@ -1,9 +1,8 @@
 package = "telegram-bot-lua"
 version = "3.1-0"
 source = {
-    url = "git://github.com/wrxck/telegram-bot-lua.git",
-    dir = "telegram-bot-lua",
-    tag = "v3.1"
+    url = "https://github.com/wrxck/telegram-bot-lua/archive/refs/tags/v3.1.tar.gz",
+    dir = "telegram-bot-lua-3.1"
 }
 description = {
     summary = "A feature-filled Telegram bot API library",


### PR DESCRIPTION
## Summary
- Fix rockspec source URLs from deprecated `git://` to HTTPS tarball URLs
- Affects both 3.0-0 and 3.1-0 rockspecs

Needed before publishing v3.1 to LuaRocks.