### PR TITLE
docs: add auto-audit badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # telegram-bot-lua
 
+[![audited by auto-audit](https://img.shields.io/badge/audited_by-auto--audit-6366f1?logo=github&logoColor=white)](https://auto-audit.hesketh.pro)
+
 A feature-filled Telegram bot API library written in Lua, created by [Matt](https://t.me/wrxck). Supports Bot API 9.4 with full coverage of all available methods.
 
 ## Installation


### PR DESCRIPTION
Adds a static badge to the README indicating this repo is audited by [auto-audit](https://auto-audit.hesketh.pro).

A **dynamic** badge showing live audit status is also available. The plugin just published `.auto-audit/status.json` to the `autoaudit/status` branch of this repo. To render it:

```markdown
[![auto-audit status](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwrxck/telegram-bot-lua%2Fautoaudit%2Fstatus%2F.auto-audit%2Fstatus.json)](https://auto-audit.hesketh.pro)
```

Decline this PR if you don't want the badge. The plugin works either way.
