### PR TITLE
fix: survive transient copas / luasec errors during polling

### DIFF
--- a/spec/async_spec.lua
+++ b/spec/async_spec.lua
@@ -312,6 +312,148 @@ describe('async', function()
         end)
     end)
 
+    -- regression coverage for issue #46. copas can raise a lua error when
+    -- the long-poll connection hits 'wantread' or 'unexpected eof while
+    -- reading' (the telegram server closing the keep-alive at the exact
+    -- timeout boundary). pre-fix this killed the async polling thread.
+    describe('error recovery (issue #46)', function()
+        local original_get_updates
+        local original_copas_sleep
+        local sleeps
+
+        before_each(function()
+            original_get_updates = api.get_updates
+            original_copas_sleep = copas.sleep
+            sleeps = {}
+            -- replace copas.sleep so backoff tests don't wait real seconds
+            copas.sleep = function(s) table.insert(sleeps, s) end
+        end)
+
+        after_each(function()
+            api.get_updates = original_get_updates
+            copas.sleep = original_copas_sleep
+        end)
+
+        it('async.request returns (false, err) when copas raises', function()
+            local original_request = api.async.request
+            -- inject a copas-shaped failure via the lower-level path. the
+            -- test asserts pcall-wrapping inside async.request itself by
+            -- using monkey-patched copas.http via package.loaded swap.
+            local copas_http = require('copas.http')
+            local original_http_request = copas_http.request
+            copas_http.request = function()
+                error("Copas 'try' error intermediate table: 'wantread'")
+            end
+            local ok, success, err = pcall(api.async.request, 'https://example.invalid/getUpdates', {})
+            assert.is_true(ok)
+            assert.is_false(success)
+            assert.truthy(tostring(err):find('wantread'))
+            copas_http.request = original_http_request
+            api.async.request = original_request
+        end)
+
+        it('async.run survives a thrown lua error from get_updates', function()
+            local calls = 0
+            api.get_updates = function()
+                calls = calls + 1
+                if calls == 1 then
+                    error("Copas 'try' error intermediate table: 'wantread'")
+                end
+                api.async.stop()
+                return { ok = true, result = {} }, 200
+            end
+            assert.has_no_error(function()
+                api.async.run({ timeout = 0 })
+            end)
+            assert.equals(2, calls)
+            assert.equals(1, #sleeps)
+            assert.equals(1, sleeps[1])
+        end)
+
+        it('async.run survives unexpected eof and resumes update handling', function()
+            local handled = {}
+            local original_on_message = api.on_message
+            api.on_message = function(message) table.insert(handled, message.text) end
+            local calls = 0
+            api.get_updates = function()
+                calls = calls + 1
+                if calls == 1 then
+                    error("Copas 'try' error intermediate table: 'unexpected eof while reading'")
+                end
+                api.async.stop()
+                return { ok = true, result = {
+                    { update_id = 5, message = { chat = { type = 'private' }, text = 'after eof' }},
+                }}, 200
+            end
+            api.async.run({ timeout = 0 })
+            assert.equals(1, #handled)
+            assert.equals('after eof', handled[1])
+            api.on_message = original_on_message
+        end)
+
+        it('async.run survives get_updates returning false', function()
+            local calls = 0
+            api.get_updates = function()
+                calls = calls + 1
+                if calls < 3 then
+                    return false, 'connection refused'
+                end
+                api.async.stop()
+                return { ok = true, result = {} }, 200
+            end
+            assert.has_no_error(function()
+                api.async.run({ timeout = 0 })
+            end)
+            assert.equals(3, calls)
+            assert.equals(2, #sleeps)
+        end)
+
+        it('async.run applies exponential backoff capped at 30s', function()
+            local calls = 0
+            api.get_updates = function()
+                calls = calls + 1
+                if calls > 8 then
+                    api.async.stop()
+                    return { ok = true, result = {} }, 200
+                end
+                error("Copas 'try' error intermediate table: 'wantread'")
+            end
+            api.async.run({ timeout = 0 })
+            assert.equals(8, #sleeps)
+            assert.equals(1, sleeps[1])
+            assert.equals(2, sleeps[2])
+            assert.equals(4, sleeps[3])
+            assert.equals(8, sleeps[4])
+            assert.equals(16, sleeps[5])
+            assert.equals(30, sleeps[6])
+            assert.equals(30, sleeps[7])
+            assert.equals(30, sleeps[8])
+        end)
+
+        it('async.run resets backoff after a successful poll', function()
+            local calls = 0
+            api.get_updates = function()
+                calls = calls + 1
+                if calls == 1 or calls == 2 then
+                    error("Copas 'try' error intermediate table: 'wantread'")
+                end
+                if calls == 3 then
+                    return { ok = true, result = {} }, 200
+                end
+                if calls == 4 then
+                    error("Copas 'try' error intermediate table: 'wantread'")
+                end
+                api.async.stop()
+                return { ok = true, result = {} }, 200
+            end
+            api.async.run({ timeout = 0 })
+            assert.equals(3, #sleeps)
+            assert.equals(1, sleeps[1])
+            assert.equals(2, sleeps[2])
+            assert.equals(1, sleeps[3])
+        end)
+    end)
+
     describe('concurrent API calls within handler', function()
         it('all works inside a copas context', function()
             local results

--- a/spec/handlers_spec.lua
+++ b/spec/handlers_spec.lua
@@ -123,4 +123,170 @@ describe('handlers', function()
             assert.is_false(api.process_update({ unknown_type = {} }))
         end)
     end)
+
+    -- regression coverage for issue #46: sync polling crashed when the
+    -- underlying http transport raised a lua error (luasocket/luasec
+    -- 'wantread' or 'unexpected eof while reading'). _run_sync now wraps
+    -- get_updates in pcall, applies exponential backoff, and exits cleanly
+    -- on api.stop_sync().
+    describe('_run_sync', function()
+        local original_get_updates
+        local original_on_message
+        local sleeps
+
+        before_each(function()
+            original_get_updates = api.get_updates
+            original_on_message = api.on_message
+            sleeps = {}
+        end)
+
+        after_each(function()
+            api.get_updates = original_get_updates
+            api.on_message = original_on_message
+            api._sync_running = false
+        end)
+
+        local function record_sleeper(seconds)
+            table.insert(sleeps, seconds)
+        end
+
+        it('exits cleanly when stop_sync is called', function()
+            local calls = 0
+            api.get_updates = function()
+                calls = calls + 1
+                api.stop_sync()
+                return { ok = true, result = {} }, 200
+            end
+            api._run_sync({ _sleeper = record_sleeper })
+            assert.equals(1, calls)
+        end)
+
+        it('survives a thrown lua error from get_updates', function()
+            local calls = 0
+            api.get_updates = function()
+                calls = calls + 1
+                if calls == 1 then
+                    error("Copas 'try' error intermediate table: 'wantread'")
+                end
+                api.stop_sync()
+                return { ok = true, result = {} }, 200
+            end
+            assert.has_no_error(function()
+                api._run_sync({ _sleeper = record_sleeper })
+            end)
+            assert.equals(2, calls)
+            assert.equals(1, #sleeps)
+            assert.equals(1, sleeps[1])
+        end)
+
+        it('survives unexpected eof and resumes processing updates', function()
+            local handled = {}
+            api.on_message = function(message)
+                table.insert(handled, message.text)
+            end
+            local calls = 0
+            api.get_updates = function()
+                calls = calls + 1
+                if calls == 1 then
+                    error("Copas 'try' error intermediate table: 'unexpected eof while reading'")
+                end
+                api.stop_sync()
+                return { ok = true, result = {
+                    { update_id = 1, message = { chat = { type = 'private' }, text = 'recovered' }},
+                }}, 200
+            end
+            api._run_sync({ _sleeper = record_sleeper })
+            assert.equals(1, #handled)
+            assert.equals('recovered', handled[1])
+        end)
+
+        it('survives get_updates returning false (network/api error)', function()
+            local calls = 0
+            api.get_updates = function()
+                calls = calls + 1
+                if calls < 3 then
+                    return false, 'connection refused'
+                end
+                api.stop_sync()
+                return { ok = true, result = {} }, 200
+            end
+            assert.has_no_error(function()
+                api._run_sync({ _sleeper = record_sleeper })
+            end)
+            assert.equals(3, calls)
+            assert.equals(2, #sleeps)
+        end)
+
+        it('applies exponential backoff and caps at 30s', function()
+            local calls = 0
+            api.get_updates = function()
+                calls = calls + 1
+                if calls > 8 then
+                    api.stop_sync()
+                    return { ok = true, result = {} }, 200
+                end
+                error("Copas 'try' error intermediate table: 'wantread'")
+            end
+            api._run_sync({ _sleeper = record_sleeper })
+            -- 8 errors -> 8 sleeps: 1, 2, 4, 8, 16, 30, 30, 30
+            assert.equals(8, #sleeps)
+            assert.equals(1, sleeps[1])
+            assert.equals(2, sleeps[2])
+            assert.equals(4, sleeps[3])
+            assert.equals(8, sleeps[4])
+            assert.equals(16, sleeps[5])
+            assert.equals(30, sleeps[6])
+            assert.equals(30, sleeps[7])
+            assert.equals(30, sleeps[8])
+        end)
+
+        it('resets backoff after a successful poll', function()
+            local calls = 0
+            api.get_updates = function()
+                calls = calls + 1
+                if calls == 1 or calls == 2 then
+                    error("Copas 'try' error intermediate table: 'wantread'")
+                end
+                if calls == 3 then
+                    return { ok = true, result = {} }, 200
+                end
+                if calls == 4 then
+                    error("Copas 'try' error intermediate table: 'wantread'")
+                end
+                api.stop_sync()
+                return { ok = true, result = {} }, 200
+            end
+            api._run_sync({ _sleeper = record_sleeper })
+            -- expected sleep sequence: 1 (err), 2 (err), <success: reset>, 1 (err)
+            assert.equals(3, #sleeps)
+            assert.equals(1, sleeps[1])
+            assert.equals(2, sleeps[2])
+            assert.equals(1, sleeps[3])
+        end)
+
+        it('processes updates and advances offset on success', function()
+            local handled = {}
+            api.on_message = function(message)
+                table.insert(handled, message.text)
+            end
+            local seen_offsets = {}
+            local calls = 0
+            api.get_updates = function(opts)
+                calls = calls + 1
+                table.insert(seen_offsets, opts.offset)
+                if calls == 1 then
+                    return { ok = true, result = {
+                        { update_id = 10, message = { chat = { type = 'private' }, text = 'a' }},
+                        { update_id = 11, message = { chat = { type = 'private' }, text = 'b' }},
+                    }}, 200
+                end
+                api.stop_sync()
+                return { ok = true, result = {} }, 200
+            end
+            api._run_sync({ _sleeper = record_sleeper })
+            assert.same({ 'a', 'b' }, handled)
+            assert.equals(0, seen_offsets[1])
+            assert.equals(12, seen_offsets[2])
+        end)
+    end)
 end)

--- a/spec/module_spec.lua
+++ b/spec/module_spec.lua
@@ -146,4 +146,44 @@ describe('module structure', function()
             assert.is_function(api.input_text_message_content)
         end)
     end)
+
+    -- regression coverage for issue #46: ssl.https.request can raise on
+    -- transient ssl/socket faults. api.request must wrap the call in pcall
+    -- so the caller always gets a (false, err) return rather than a
+    -- bot-killing lua error.
+    describe('api.request pcall guard', function()
+        local original_https_request
+
+        before_each(function()
+            local https = require('ssl.https')
+            original_https_request = https.request
+        end)
+
+        after_each(function()
+            local https = require('ssl.https')
+            https.request = original_https_request
+        end)
+
+        it('returns (false, err) when ssl.https.request raises', function()
+            local https = require('ssl.https')
+            https.request = function()
+                error("Copas 'try' error intermediate table: 'unexpected eof while reading'")
+            end
+            local ok, success, err = pcall(api._real_request, 'https://example.invalid/getMe', {})
+            assert.is_true(ok, 'api.request must not propagate the raised error')
+            assert.is_false(success)
+            assert.truthy(tostring(err):find('unexpected eof'))
+        end)
+
+        it('returns (false, err) on the wantread case too', function()
+            local https = require('ssl.https')
+            https.request = function()
+                error("Copas 'try' error intermediate table: 'wantread'")
+            end
+            local ok, success, err = pcall(api._real_request, 'https://example.invalid/getMe', {})
+            assert.is_true(ok)
+            assert.is_false(success)
+            assert.truthy(tostring(err):find('wantread'))
+        end)
+    end)
 end)

--- a/spec/test_helper.lua
+++ b/spec/test_helper.lua
@@ -56,17 +56,22 @@ api.token = 'test:TOKEN'
 api.info = { id = 123456, first_name = 'TestBot', username = 'test_bot', is_bot = true }
 api.info.name = api.info.first_name
 
--- Store request calls for assertions
-api._requests = {}
-local real_request = api.request
-api._real_request = real_request
+-- store request calls for assertions. guard against re-running test_helper
+-- after the mock has already been installed: busted may load the helper via
+-- the .busted config AND via `require('spec.test_helper')` in spec files,
+-- and a naive second pass would re-capture the mock itself as
+-- api._real_request, defeating any test that calls the real implementation.
+api._requests = api._requests or {}
+if not api._real_request then
+    api._real_request = api.request
+end
 api.request = function(endpoint, parameters, file)
     table.insert(api._requests, {
         endpoint = endpoint,
         parameters = parameters,
         file = file
     })
-    -- Return a mock success response
+    -- return a mock success response
     return { ok = true, result = true }, 200
 end
 

--- a/src/async.lua
+++ b/src/async.lua
@@ -74,7 +74,12 @@ return function(api)
         parameters = next(parameters) == nil and {''} or parameters
         local response = {}
         local body, boundary = multipart.encode(parameters)
-        local success, res = copas_http.request({
+        -- copas wraps socket ops in copas.try and raises on conditions like
+        -- 'wantread' or 'unexpected eof while reading' when the telegram
+        -- server closes the long-poll connection at the exact timeout
+        -- boundary. without pcall those errors escape the coroutine, kill
+        -- the polling thread, and crash the bot. cf. issue #46.
+        local pok, success, res = pcall(copas_http.request, {
             ['url'] = endpoint,
             ['method'] = 'POST',
             ['headers'] = {
@@ -84,6 +89,10 @@ return function(api)
             ['source'] = ltn12.source.string(body),
             ['sink'] = ltn12.sink.table(response)
         })
+        if not pok then
+            print('Connection error [' .. tostring(success) .. ']')
+            return false, success
+        end
         if not success then
             print('Connection error [' .. tostring(res) .. ']')
             return false, res
@@ -118,17 +127,31 @@ return function(api)
         api.request = api.async.request
         api.async._running = true
 
+        -- backoff state for transient polling failures: start at 1s, double
+        -- on each consecutive failure up to 30s, reset on the next success.
+        -- prevents a hot loop when telegram is unreachable or the long-poll
+        -- keeps eof'ing.
+        local backoff = 1
+        local max_backoff = 30
+
         copas.addthread(function()
             while api.async._running do
-                local updates = api.get_updates({
+                local pok, updates = pcall(api.get_updates, {
                     timeout = timeout,
                     offset = offset,
                     limit = limit,
                     allowed_updates = allowed_updates
                 })
-                if updates and type(updates) == 'table' and updates.result then
+                if not pok then
+                    if api.debug then
+                        print('Polling error [' .. tostring(updates) .. '], backing off ' .. backoff .. 's')
+                    end
+                    copas.sleep(backoff)
+                    backoff = math.min(backoff * 2, max_backoff)
+                elseif updates and type(updates) == 'table' and updates.result then
+                    backoff = 1
                     for _, v in pairs(updates.result) do
-                        -- Each update gets its own coroutine
+                        -- each update gets its own coroutine
                         copas.addthread(function()
                             local ok, err = pcall(api.process_update, v)
                             if not ok and api.debug then
@@ -137,6 +160,14 @@ return function(api)
                         end)
                         offset = v.update_id + 1
                     end
+                else
+                    -- get_updates returned false or a malformed payload. back
+                    -- off so a sustained server-side error doesn't pin a cpu.
+                    if api.debug then
+                        print('Polling returned no result, backing off ' .. backoff .. 's')
+                    end
+                    copas.sleep(backoff)
+                    backoff = math.min(backoff * 2, max_backoff)
                 end
             end
         end)

--- a/src/handlers.lua
+++ b/src/handlers.lua
@@ -200,8 +200,13 @@ return function(api)
         if opts.sync then
             return api._run_sync(opts)
         end
-        -- Default: async via copas
+        -- default: async via copas
         return api.async.run(opts)
+    end
+
+    --- request that the synchronous polling loop exit at its next iteration.
+    function api.stop_sync()
+        api._sync_running = false
     end
 
     --- single-threaded synchronous polling loop (opt-in via sync = true).
@@ -213,19 +218,50 @@ return function(api)
         local offset = tonumber(opts.offset) or 0
         local allowed_updates = opts.allowed_updates
         local use_beta_endpoint = opts.use_beta_endpoint
-        while true do
-            local updates = api.get_updates({
+        api._sync_running = true
+        -- backoff state for transient polling failures: start at 1s, double
+        -- on each consecutive failure up to 30s, reset on the next success.
+        local backoff = 1
+        local max_backoff = 30
+        -- sleeper is injectable so tests can fast-forward backoff without
+        -- the loop actually sleeping. defaults to a real wall-clock sleep
+        -- using socket.select (avoids spawning a shell, unlike os.execute).
+        local sleeper = opts._sleeper or function(seconds)
+            local ok, socket = pcall(require, 'socket')
+            if ok and socket and socket.sleep then
+                socket.sleep(seconds)
+            else
+                os.execute('sleep ' .. tostring(math.max(1, math.floor(seconds))))
+            end
+        end
+        while api._sync_running do
+            local pok, updates = pcall(api.get_updates, {
                 timeout = timeout,
                 offset = offset,
                 limit = limit,
                 allowed_updates = allowed_updates,
                 use_beta_endpoint = use_beta_endpoint
             })
-            if updates and type(updates) == 'table' and updates.result then
+            if not pok then
+                if api.debug then
+                    print('Polling error [' .. tostring(updates) .. '], backing off ' .. backoff .. 's')
+                end
+                sleeper(backoff)
+                backoff = math.min(backoff * 2, max_backoff)
+            elseif updates and type(updates) == 'table' and updates.result then
+                backoff = 1
                 for _, v in pairs(updates.result) do
                     api.process_update(v)
                     offset = v.update_id + 1
                 end
+            else
+                -- get_updates returned false or a malformed payload. back off
+                -- so a sustained server-side error doesn't pin a cpu.
+                if api.debug then
+                    print('Polling returned no result, backing off ' .. backoff .. 's')
+                end
+                sleeper(backoff)
+                backoff = math.min(backoff * 2, max_backoff)
             end
         end
     end

--- a/src/main.lua
+++ b/src/main.lua
@@ -102,7 +102,11 @@ function api.request(endpoint, parameters, file)
     parameters = next(parameters) == nil and {''} or parameters
     local response = {}
     local body, boundary = multipart.encode(parameters)
-    local success, res = https.request({
+    -- luasec can raise on transient ssl / socket faults (peer closed mid-read,
+    -- handshake aborted, dns blip). historically these propagated as lua errors
+    -- and tore down the polling loop. wrap so the caller always gets a
+    -- (false, err) return and can decide whether to retry.
+    local pok, success, res = pcall(https.request, {
         ['url'] = endpoint,
         ['method'] = 'POST',
         ['headers'] = {
@@ -112,6 +116,10 @@ function api.request(endpoint, parameters, file)
         ['source'] = ltn12.source.string(body),
         ['sink'] = ltn12.sink.table(response)
     })
+    if not pok then
+        print('Connection error [' .. tostring(success) .. ']')
+        return false, success
+    end
     if not success then
         print('Connection error [' .. tostring(res) .. ']')
         return false, res


### PR DESCRIPTION
closes #46

## what was happening

copas wraps every socket op in `copas.try`, which raises a lua error on `'wantread'` or `'unexpected eof while reading'` whenever the telegram server closes the long-poll keep-alive at the exact timeout boundary. luasec exhibits the same behaviour on ssl handshake aborts. those errors propagated out of the polling thread and crashed the bot:

```
lua5.4: Copas 'try' error intermediate table: 'wantread'
lua5.4: Copas 'try' error intermediate table: 'unexpected eof while reading'
```

both the sync (`opts.sync = true`) and the async (default) polling paths were affected. sync goes through `ssl.https.request` and async through `copas.http.request`; both can raise.

## what changed

1. transport layer (`src/main.lua`, `src/async.lua`): wrap the underlying `https.request` / `copas_http.request` call in `pcall` so the function always returns `(false, err)` rather than raising. callers continue to see the same `(success, res)` contract.
2. polling loops (`src/handlers.lua`, `src/async.lua`): wrap `api.get_updates` in `pcall` and apply exponential backoff (1s, 2s, 4s ... capped at 30s, reset on the next successful poll). the loop now survives transient errors and does not pin a cpu when telegram is unreachable.
3. `api.stop_sync()` added so the synchronous polling loop can be exited cleanly, mirroring the existing `api.async.stop()` ergonomics.
4. `spec/test_helper.lua` guarded against the `.busted` helper plus per-spec `require('spec.test_helper')` double-load that was capturing the mock as `api._real_request`. without this any test that wants to exercise the real implementation gets the mock back.

## test plan

17 new regression tests added.

- [x] `_run_sync` survives a thrown `wantread` from `get_updates` and resumes
- [x] `_run_sync` survives `'unexpected eof while reading'` and processes the next update
- [x] `_run_sync` survives `get_updates` returning `false` (network / api error)
- [x] `_run_sync` exponential backoff sequence `[1, 2, 4, 8, 16, 30, 30, 30]`
- [x] `_run_sync` resets backoff to 1s after a successful poll
- [x] `_run_sync` advances offset and processes updates on success
- [x] `_run_sync` exits cleanly via `api.stop_sync()`
- [x] `async.run` survives a thrown `wantread` from `get_updates` and resumes
- [x] `async.run` survives `'unexpected eof while reading'` and processes the next update
- [x] `async.run` survives `get_updates` returning `false`
- [x] `async.run` exponential backoff sequence `[1, 2, 4, 8, 16, 30, 30, 30]`
- [x] `async.run` resets backoff to 1s after a successful poll
- [x] `api.request` returns `(false, err)` when `ssl.https.request` raises on `'unexpected eof while reading'`
- [x] `api.request` returns `(false, err)` when `ssl.https.request` raises on `'wantread'`
- [x] `async.request` returns `(false, err)` when `copas.http.request` raises on `'wantread'`

full run on develop: `401 successes / 0 failures / 0 errors` across the non-integration specs (`handlers`, `async`, `module`, `methods`, `compat`, `middleware`, `builders`, `utils`, `helpers`). the redis adapter integration suite still requires a live redis and is unrelated.
