### PR TITLE
docs: cover Bot API 10.1 in README and guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ src/
   tools.lua             -- Utility functions (formatting, file ops, etc.)
   handlers.lua          -- Update routing and on_* handler stubs (async-first)
   builders.lua          -- Keyboard, inline result, and type constructors
+  builders_rich.lua     -- Rich message builders (RichText/RichBlock DSL)
   helpers.lua           -- Member status check helpers
   utils.lua             -- Bot development utilities (fmt, commands, pagination)
   compat.lua            -- v2 backward compatibility layer
@@ -130,6 +131,7 @@ src/
     checklists.lua      -- Checklist methods
     stories.lua         -- Story methods
     suggested_posts.lua -- Suggested post methods
+    rich.lua            -- Rich message methods (send_rich_message, drafts)
 ```
 
 ## Testing

--- a/docs/builders.md
+++ b/docs/builders.md
@@ -104,11 +104,92 @@ api.input_media_animation(media, thumbnail, caption, parse_mode, width, height, 
 api.input_media_audio(media, thumbnail, caption, parse_mode, duration, performer, title)
 api.input_media_document(media, thumbnail, caption, parse_mode)
 
+-- Bot API 10.x media types
+api.input_media_sticker(media, emoji)
+api.input_media_location(latitude, longitude, horizontal_accuracy)
+api.input_media_venue(latitude, longitude, title, address, opts)
+api.input_media_live_photo(media, photo, opts)
+api.input_media_link(url)
+api.input_paid_media_live_photo(media, photo)
+
 -- Chainable builder
 local media = api.input_media()
     :photo('photo_file_id', 'First photo')
     :photo('photo_file_id_2', 'Second photo')
     :video('video_file_id', 'A video', 1280, 720, 120)
+```
+
+## Rich Message Builders (Bot API 10.1)
+
+### Sending
+
+Build an `InputRichMessage` (what you send) from HTML or Markdown — supply exactly one:
+
+```lua
+api.input_rich_message({ html = '<b>Hi</b>', is_rtl = false, skip_entity_detection = false })
+api.input_rich_message({ markdown = '*Hi*' })
+
+api.input_rich_message_content(rich_message)  -- wrap for inline/guest/web app results
+api.link(url)                                 -- a Link object
+```
+
+Pass the result to `api.send_rich_message`, `api.send_rich_message_draft`, or `edit_message_text`'s `rich_message` opt (see [Methods](methods.md#rich-messages)).
+
+### Received structure (RichText / RichBlock)
+
+These model the parsed `message.rich_message` (a `RichMessage` of `RichBlock`s, whose text is `RichText`). A rich text's `text` argument may be a plain string, an array, or another rich text.
+
+```lua
+api.rich_message(blocks, is_rtl)
+
+-- rich text
+api.rich_text_bold(text)         api.rich_text_italic(text)
+api.rich_text_underline(text)    api.rich_text_strikethrough(text)
+api.rich_text_spoiler(text)      api.rich_text_subscript(text)
+api.rich_text_superscript(text)  api.rich_text_marked(text)
+api.rich_text_code(text)
+api.rich_text_date_time(text, unix_time, date_time_format)
+api.rich_text_text_mention(text, user)
+api.rich_text_custom_emoji(custom_emoji_id, alternative_text)   -- no text field
+api.rich_text_mathematical_expression(expression)               -- no text field
+api.rich_text_url(text, url)
+api.rich_text_email_address(text, email_address)
+api.rich_text_phone_number(text, phone_number)
+api.rich_text_bank_card_number(text, bank_card_number)
+api.rich_text_mention(text, username)
+api.rich_text_hashtag(text, hashtag)
+api.rich_text_cashtag(text, cashtag)
+api.rich_text_bot_command(text, bot_command)
+api.rich_text_anchor(name)                                      -- no text field
+api.rich_text_anchor_link(text, anchor_name)
+api.rich_text_reference(text, name)
+api.rich_text_reference_link(text, reference_name)
+
+-- rich blocks
+api.rich_block_paragraph(text)
+api.rich_block_heading(text, size)                  -- size 1-6
+api.rich_block_preformatted(text, language)
+api.rich_block_footer(text)
+api.rich_block_divider()
+api.rich_block_mathematical_expression(expression)
+api.rich_block_anchor(name)
+api.rich_block_list(items)
+api.rich_block_list_item(label, blocks, opts)       -- opts: has_checkbox, is_checked, value, type
+api.rich_block_blockquote(blocks, credit)
+api.rich_block_pullquote(text, credit)
+api.rich_block_collage(blocks, caption)
+api.rich_block_slideshow(blocks, caption)
+api.rich_block_table(cells, opts)                   -- opts: is_bordered, is_striped, caption
+api.rich_block_table_cell(text, opts)               -- opts: is_header, colspan, rowspan, align, valign
+api.rich_block_details(summary, blocks, is_open)
+api.rich_block_map(location, opts)                  -- opts: zoom, width, height, caption
+api.rich_block_animation(animation, opts)           -- opts: has_spoiler, caption
+api.rich_block_audio(audio, caption)
+api.rich_block_photo(photo, opts)                   -- opts: has_spoiler, caption
+api.rich_block_video(video, opts)                   -- opts: has_spoiler, caption
+api.rich_block_voice_note(voice_note, caption)
+api.rich_block_caption(text, credit)
+api.rich_block_thinking(text)                       -- drafts only
 ```
 
 ## Prices

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -20,6 +20,7 @@ api.send_video(chat_id, video, opts)
 api.send_animation(chat_id, animation, opts)
 api.send_voice(chat_id, voice, opts)
 api.send_video_note(chat_id, video_note, opts)
+api.send_live_photo(chat_id, live_photo, photo, opts)
 api.send_media_group(chat_id, media, opts)
 api.send_location(chat_id, latitude, longitude, opts)
 api.send_venue(chat_id, latitude, longitude, title, address, opts)
@@ -28,6 +29,8 @@ api.send_poll(chat_id, question, options, opts)
 api.send_dice(chat_id, opts)
 api.send_chat_action(chat_id, action, opts)
 api.set_message_reaction(chat_id, message_id, opts)
+api.delete_message_reaction(chat_id, message_id, opts)
+api.delete_all_message_reactions(chat_id, opts)
 api.send_paid_media(chat_id, star_count, media, opts)
 ```
 
@@ -64,6 +67,10 @@ Shorthand for sending a reply to an existing message:
 api.send_reply(message, 'Reply text', { parse_mode = 'HTML' })
 ```
 
+### Poll additions (Bot API 10.x)
+
+`send_poll` accepts media and channel-poll opts: `media` and `explanation_media` (build with the `api.input_media_*` builders), `members_only`, and `country_codes`. The minimum number of options is now 1.
+
 ## Edit Methods
 
 ```lua
@@ -78,6 +85,33 @@ api.delete_message(chat_id, message_id)
 api.delete_messages(chat_id, message_ids)
 ```
 
+`edit_message_text` also accepts a `rich_message` opt (Bot API 10.1) — see [Rich Messages](#rich-messages).
+
+## Rich Messages
+
+Rich messages (Bot API 10.1) carry structured, streamable formatted content described with HTML or Markdown.
+
+```lua
+api.send_rich_message(chat_id, rich_message, opts)
+api.send_rich_message_draft(chat_id, draft_id, rich_message, opts)
+```
+
+Build the `rich_message` (an InputRichMessage) with `api.input_rich_message`:
+
+```lua
+api.send_rich_message(chat_id, api.input_rich_message({ html = '<b>Hello</b>' }))
+
+-- stream a draft (e.g. an AI reply) by repeating with the same draft_id
+api.send_rich_message_draft(chat_id, 1, api.input_rich_message({ markdown = '*thinking...*' }))
+
+-- edit a message's rich content
+api.edit_message_text(chat_id, message_id, nil, {
+    rich_message = api.input_rich_message({ html = '<i>updated</i>' })
+})
+```
+
+See [Builders](builders.md#rich-message-builders-bot-api-101) for the rich text/block constructors.
+
 ## Updates
 
 ```lua
@@ -91,7 +125,7 @@ api.get_webhook_info()
 
 ```lua
 api.get_chat(chat_id)
-api.get_chat_administrators(chat_id)
+api.get_chat_administrators(chat_id, opts)   -- opts.return_bots to include bot admins
 api.get_chat_member_count(chat_id)
 api.get_chat_member(chat_id, user_id)
 api.leave_chat(chat_id)
@@ -111,6 +145,8 @@ api.edit_chat_invite_link(chat_id, invite_link, opts)
 api.revoke_chat_invite_link(chat_id, invite_link)
 api.approve_chat_join_request(chat_id, user_id)
 api.decline_chat_join_request(chat_id, user_id)
+api.answer_chat_join_request_query(chat_join_request_query_id, result)   -- result: 'approve' | 'decline' | 'queue'
+api.send_chat_join_request_web_app(chat_join_request_query_id, web_app_url)
 api.get_user_chat_boosts(chat_id, user_id)
 ```
 
@@ -171,6 +207,7 @@ api.delete_sticker_set(name)
 ```lua
 api.answer_inline_query(inline_query_id, results, opts)
 api.answer_web_app_query(web_app_query_id, result)
+api.answer_guest_query(guest_query_id, result)
 api.answer_callback_query(callback_query_id, opts)
 api.send_inline_article(inline_query_id, title, description, message_text, parse_mode, reply_markup)
 api.send_inline_article_url(inline_query_id, title, url, hide_url, input_message_content, reply_markup, id)
@@ -220,6 +257,9 @@ api.set_my_default_administrator_rights(opts)
 api.get_my_default_administrator_rights(opts)
 api.set_my_profile_photo(opts)
 api.remove_my_profile_photo(opts)
+api.get_managed_bot_access_settings(user_id)
+api.set_managed_bot_access_settings(user_id, is_access_restricted, opts)
+api.get_user_personal_chat_messages(user_id, limit)
 ```
 
 ## Passport


### PR DESCRIPTION
Follow-up to #48 — makes the narrative docs match the shipped 10.1 surface.

## README
- The module-structure diagram was missing the two new modules; adds `builders_rich.lua` and `methods/rich.lua`.

## docs/methods.md
- `send_live_photo`, `delete_message_reaction`, `delete_all_message_reactions`, `answer_guest_query`, `answer_chat_join_request_query`, `send_chat_join_request_web_app`, `get_managed_bot_access_settings`, `set_managed_bot_access_settings`, `get_user_personal_chat_messages`
- `get_chat_administrators` `return_bots`, `send_poll` media/channel opts, `edit_message_text` `rich_message`
- new **Rich Messages** section (`send_rich_message`, `send_rich_message_draft`, draft streaming, edit)

## docs/builders.md
- 10.x input-media builders (`input_media_sticker`/`location`/`venue`/`live_photo`/`link`, `input_paid_media_live_photo`)
- new **Rich Message Builders** section: `input_rich_message`, `input_rich_message_content`, `link`, and the full `RichText*`/`RichBlock*` constructor DSL

## Verification
- No stale `9.6` references remain in any `docs/*.md`.
- All **260** `api.*` symbols referenced across both guides resolve to real functions/tables.

The auto-generated LDoc HTML site was already refreshed in #48; this brings the hand-written guides into line.